### PR TITLE
replaced double spaces with tab

### DIFF
--- a/src/components/Atom.jsx
+++ b/src/components/Atom.jsx
@@ -5,6 +5,7 @@ import { html } from 'common-tags';
 class Atom extends Component {
 
   renderSnippet(snippet) {
+    snippet = snippet.split('  ').join('\\t');
     return html`
       '${this.props.description}':
         'prefix': '${this.props.tabtrigger}'

--- a/src/components/SublimeText.jsx
+++ b/src/components/SublimeText.jsx
@@ -6,8 +6,7 @@ class SublimeText extends Component {
 
   renderSnippet(snippet) {
     const regexpMagic = /(\$)([a-z(]+)([^$])/gi;
-    let escapedSnippet = snippet.replace(regexpMagic, '\\$1$2$3');
-    escapedSnippet = escapedSnippet.split('  ').join('\\t');
+    const escapedSnippet = snippet.replace(regexpMagic, '\\$1$2$3');
 
     return html`
       <snippet>

--- a/src/components/SublimeText.jsx
+++ b/src/components/SublimeText.jsx
@@ -6,7 +6,8 @@ class SublimeText extends Component {
 
   renderSnippet(snippet) {
     const regexpMagic = /(\$)([a-z(]+)([^$])/gi;
-    const escapedSnippet = snippet.replace(regexpMagic, '\\$1$2$3');
+    let escapedSnippet = snippet.replace(regexpMagic, '\\$1$2$3');
+    escapedSnippet = escapedSnippet.split('  ').join('\\t');
 
     return html`
       <snippet>

--- a/src/components/VSCode.jsx
+++ b/src/components/VSCode.jsx
@@ -11,8 +11,10 @@ class VSCode extends Component {
     const separatedSnippetLength = separatedSnippet.length;
 
     // add double quotes around each line apart from the last one
+    // replace double spaces with tab
     const newSnippet = separatedSnippet.map((line, index) => {
-      return index === separatedSnippetLength - 1 ? `"${line}"` : `"${line}",`;
+      const processedLine = line.split('  ').join('\\t');
+      return index === separatedSnippetLength - 1 ? `"${processedLine}"` : `"${processedLine}",`;
     });
 
     return html`


### PR DESCRIPTION
replaced default behavior of inserting two spaces with '/t'. This helps with editors configured with different number of spaces for tab.