### PR TITLE
Updated to preserve tabs in VS Code

### DIFF
--- a/src/components/VSCode.jsx
+++ b/src/components/VSCode.jsx
@@ -7,7 +7,7 @@ class VSCode extends Component {
 
     // escape " with \"
     // split lines by line-break
-    const separatedSnippet = snippet.replace(/"/g, '\\"').split('\n');
+    const separatedSnippet = snippet.replace(/"/g, '\\"').replace(/\t/g, '\\t').split('\n');
     const separatedSnippetLength = separatedSnippet.length;
 
     // add double quotes around each line apart from the last one


### PR DESCRIPTION
For code that uses tabs instead of spaces, this code will preserve those tabs in the VS Code snippet using the tab control character.