### PR TITLE
Fix `\` and `$` escape error in VSCode snippet

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "npm run dev",
     "dev": "webpack-dev-server --mode development --open",
     "build": "rm -rf dist && webpack --mode production"
   },

--- a/src/components/VSCode.js
+++ b/src/components/VSCode.js
@@ -2,23 +2,21 @@ import React from 'react';
 import { html } from 'common-tags';
 import { Consumer } from './Context';
 
+const formatSnippet = snippet => (
+  snippet
+    .replace(/\\/g, '\\\\\\\\') /* escape `\`: in JSON, `\\` or `\\\\` escape one `\` */
+    .replace(/"/g, '\\"') /* escape quotes */
+    .split('\n') /* split lines */
+    .map(line => `"${line}"`) /* add quotes to lines */
+    .join(',\n')
+);
+
 const renderSnippet = (snippet, tabtrigger, description) => {
-
-  // escape " with \"
-  // split lines by line-break
-  const separatedSnippet = snippet.replace(/"/g, '\\"').split('\n');
-  const separatedSnippetLength = separatedSnippet.length;
-
-  // add double quotes around each line apart from the last one
-  const newSnippet = separatedSnippet.map((line, index) => {
-    return index === separatedSnippetLength - 1 ? `"${line}"` : `"${line}",`;
-  });
-
   return html`
     "${description}": {
       "prefix": "${tabtrigger}",
       "body": [
-        ${newSnippet.join('\n')}
+        ${formatSnippet(snippet)}
       ],
       "description": "${description}"
     }

--- a/src/components/VSCode.js
+++ b/src/components/VSCode.js
@@ -6,6 +6,7 @@ const formatSnippet = snippet => (
   snippet
     .replace(/\\/g, '\\\\\\\\') /* escape `\`: in JSON, `\\` or `\\\\` escape one `\` */
     .replace(/"/g, '\\"') /* escape quotes */
+    .replace(/\$/g, '\\\\$') /* escape `$`: VSCode use `$` as placeholder*/
     .split('\n') /* split lines */
     .map(line => `"${line}"`) /* add quotes to lines */
     .join(',\n')


### PR DESCRIPTION
## Examples

VSCode JSON snippet => true output

- "\\\\" => "\"
- "\\\\\\\\" => "\\"
- "\\\\begin" => "\begin"
- "\\$" => "$"
- "\\$abc" => "$abc"
- "\\\\\\$" => "\$"
- "\\\\\\$abc" => "\$abc"
- "\\\\\\\\\\$" => "\\$"
- "\\\\\\\\\\$abc" => "\\$abc"

