### PR TITLE
Fix #25 : escape backslash in VS Code

### DIFF
--- a/src/components/VSCode.js
+++ b/src/components/VSCode.js
@@ -6,7 +6,7 @@ const renderSnippet = (snippet, tabtrigger, description) => {
 
   // escape " with \"
   // split lines by line-break
-  const separatedSnippet = snippet.replace(/"/g, '\\"').split('\n');
+  const separatedSnippet = snippet.replace('\\','\\\\').replace(/"/g, '\\"').split('\n');
   const separatedSnippetLength = separatedSnippet.length;
 
   // add double quotes around each line apart from the last one


### PR DESCRIPTION
#25 
I solve the issue by replacing the backslash to double backslash in VS Code