### PR TITLE
update sublime.js for some formatting

### DIFF
--- a/src/components/SublimeText.js
+++ b/src/components/SublimeText.js
@@ -10,12 +10,12 @@ const renderSnippet = (snippet, tabtrigger, description) => {
     <snippet>
       <content><![CDATA[
     ${escapedSnippet}
-    ]]></content >
-      <description>${description}</description>
+    ]]></content>
       <tabTrigger>${tabtrigger}</tabTrigger>
+      <description>${description}</description>
       <!-- Optional: Set a scope to limit where the snippet will trigger -->
       <!-- <scope >source.python</scope > -->
-    </snippet >
+    </snippet>
   `;
 };
 


### PR DESCRIPTION
http://sublimetext.info/docs/en/extensibility/snippets.html
In the official documentation the tabTrigger part comes before description, also there is no space in the closing tags </snippet> and </content>.
Snippets generated with this format are compatible with https://xiaoouwang.github.io/batch_snippets_generator_converter_for_Vsc_Sublime_Atom/