### PR TITLE
Fixes issue #68 Handle bash variable escapes in body

### DIFF
--- a/src/components/VSCode.js
+++ b/src/components/VSCode.js
@@ -8,6 +8,8 @@ const renderSnippet = (snippet, tabtrigger, description) => {
   const separatedSnippet = snippet
     .replace(/\\/g, "\\\\")
     .replace(/"/g, '\\"')
+    .replace(/\$\{(\w+)\}/g, "\\\\$${$1\\\\}")
+    .replace(/\$(\w+)/g, "\\\\$$$1")
     .split("\n");
   const separatedSnippetLength = separatedSnippet.length;
 


### PR DESCRIPTION
* Added replace for bash variables of format `${variable}` and `$variable`
* Additional testing should be done to ensure that tab stop placeholder variables such as `${1:placeholder}` are still properly handled. The replace is only looking for word characters after `${` and before `}` so shouldn't replace when `:` is present. 
* Tested with the following snippet text and verified output was as expected. Additional testing should be done to ensure placeholder

```bash
function blog() {
  local msg
  local logtype
  local loglevel
  local logfile txtblu txtgrn txtylw txtred txtrst thisfunc
  loglevel=4
  logfile="$(mktemp -t "$(basename "$0")" || exit 1)"
  logtype="$1"
  msg="$2"
  datetime="$(date +'%F.%H:%M:%S')"
  txtblu=$(tput setaf 12) # Blue
  txtgrn=$(tput setaf 10) # Green
  txtylw=$(tput setaf 11) # Yellow
  txtred=$(tput setaf 1) # Red
  txtrst=$(tput sgr0)
  thisfunc="${FUNCNAME[*]/blog/}"
  thisfunc="${thisfunc/main /}"
  logformat="[${logtype}]\t${datetime}\tfuncname: ${thisfunc}\t[line:$(caller 0 | cut -f 1 -d ' ')]\t${msg}"
  {
    case $logtype in
      debug)
        [[ $loglevel -le 0 ]] && echo -e "${txtblu}${logformat}${txtrst}"
        ;;
      info)
        [[ $loglevel -le 1 ]] && echo -e "${txtgrn}${logformat}${txtrst}"
        ;;
      warn)
        [[ $loglevel -le 2 ]] && echo -e "${txtylw}${logformat}${txtrst}"
        ;;
      error)
        [[ $loglevel -le 3 ]] && echo -e "${txtred}${logformat}${txtrst}"
        ;;
    esac
  } | tee -a "$logfile"
}
```

Issue:  #68

